### PR TITLE
Use UIDL aware logout redirect strategy

### DIFF
--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
@@ -230,7 +230,7 @@ public class SingleSignOnConfiguration extends VaadinWebSecurity {
                 } catch (IOException | ServletException e) {
                     // Raise a warning log message about the failure.
                     LOGGER.warn("There was an error notifying the OIDC "
-                            + "provide of the user logout", e);
+                            + "provider of the user logout", e);
                 }
             });
         }

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/UidlExpiredSessionStrategy.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/UidlExpiredSessionStrategy.java
@@ -12,7 +12,7 @@ import org.springframework.security.web.session.SessionInformationExpiredStrateg
 import com.vaadin.flow.server.HandlerHelper;
 
 /**
- * The strategy to handle when an expired sessions is detected.
+ * A strategy to handle expired sessions which is aware of UIDL requests.
  *
  * @author Vaadin Ltd
  * @since 1.0

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/UidlRedirectStrategy.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/UidlRedirectStrategy.java
@@ -1,0 +1,31 @@
+package com.vaadin.sso.starter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.springframework.security.web.DefaultRedirectStrategy;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.HandlerHelper;
+
+/**
+ * A strategy to handle redirects which is aware of UIDL requests.
+ *
+ * @author Vaadin Ltd
+ * @since 1.0
+ */
+public class UidlRedirectStrategy extends DefaultRedirectStrategy {
+
+    @Override
+    public void sendRedirect(HttpServletRequest request,
+            HttpServletResponse response, String url) throws IOException {
+        final var servletMapping = request.getHttpServletMapping().getPattern();
+        if (HandlerHelper.isFrameworkInternalRequest(servletMapping, request)) {
+            UI.getCurrent().getPage().setLocation(url);
+        } else {
+            super.sendRedirect(request, response, url);
+        }
+    }
+}

--- a/sso-kit-starter/src/test/java/com/vaadin/sso/starter/AuthenticationContextTest.java
+++ b/sso-kit-starter/src/test/java/com/vaadin/sso/starter/AuthenticationContextTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -17,6 +18,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.internal.CurrentInstance;
 import com.vaadin.flow.server.VaadinRequest;
 import com.vaadin.flow.server.VaadinResponse;
@@ -26,6 +28,8 @@ import com.vaadin.sso.starter.SingleSignOnConfiguration.DefaultAuthenticationCon
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -65,7 +69,7 @@ public class AuthenticationContextTest {
     }
 
     @Test
-    public void logoutInvokesHandlersOnCurrentRequest()
+    public void logoutInvokesHandlersOnCurrentUI()
             throws IOException, ServletException {
         var req = mock(VaadinServletRequest.class);
         var httpReq = mock(HttpServletRequest.class);
@@ -76,6 +80,10 @@ public class AuthenticationContextTest {
         var httpRes = mock(HttpServletResponse.class);
         when(res.getHttpServletResponse()).thenReturn(httpRes);
         CurrentInstance.set(VaadinResponse.class, res);
+
+        var ui = mock(UI.class, Answers.RETURNS_DEEP_STUBS);
+        doCallRealMethod().when(ui).accessSynchronously(any());
+        CurrentInstance.set(UI.class, ui);
 
         var auth = mock(Authentication.class);
         SecurityContextHolder.setContext(new SecurityContextImpl(auth));

--- a/sso-kit-starter/src/test/java/com/vaadin/sso/starter/UidlRedirectStrategyTest.java
+++ b/sso-kit-starter/src/test/java/com/vaadin/sso/starter/UidlRedirectStrategyTest.java
@@ -1,0 +1,77 @@
+package com.vaadin.sso.starter;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.component.page.Page;
+import com.vaadin.flow.internal.CurrentInstance;
+import com.vaadin.flow.shared.ApplicationConstants;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UidlRedirectStrategyTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private HttpServletRequest request;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private HttpServletResponse response;
+
+    private UidlRedirectStrategy strategy;
+
+    @BeforeEach
+    public void setup() {
+        strategy = new UidlRedirectStrategy();
+        when(request.getHttpServletMapping().getPattern()).thenReturn("/");
+    }
+
+    @AfterEach
+    public void cleanup() {
+        CurrentInstance.clearAll();
+    }
+
+    @Test
+    public void isInternalRequest_setPageLocation()
+            throws IOException, ServletException {
+        when(request.getParameter(ApplicationConstants.REQUEST_TYPE_PARAMETER))
+                .thenReturn(ApplicationConstants.REQUEST_TYPE_UIDL);
+
+        var ui = mock(UI.class, Answers.RETURNS_DEEP_STUBS);
+        CurrentInstance.set(UI.class, ui);
+
+        var page = mock(Page.class);
+        when(ui.getPage()).thenReturn(page);
+
+        strategy.sendRedirect(request, response, "/foo");
+
+        verify(page).setLocation("/foo");
+    }
+
+    @Test
+    public void isExternalRequest_useDefaultRedirect()
+            throws IOException, ServletException {
+        when(request.getContextPath()).thenReturn("");
+        when(response.encodeRedirectURL(anyString()))
+                .thenAnswer(i -> i.getArguments()[0]);
+
+        strategy.sendRedirect(request, response, "/foo");
+
+        verify(response).sendRedirect("/foo");
+    }
+}


### PR DESCRIPTION
Adds a custom UIDL aware logout redirect strategy and calls the logout success-handler inside `UI::accessSynchronously`.

Closes #42 