### PR TITLE
Add exception message to the condition outcome

### DIFF
--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/LicenseCheckCondition.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/LicenseCheckCondition.java
@@ -37,8 +37,8 @@ class LicenseCheckCondition extends SpringBootCondition {
 
             return ConditionOutcome.match();
         } catch (LicenseException e) {
-            return ConditionOutcome
-                    .noMatch("No valid license found for " + PRODUCT_NAME);
+            final var message = e.getMessage();
+            return ConditionOutcome.noMatch(message);
         }
     }
 

--- a/sso-kit-starter/src/test/java/com/vaadin/sso/starter/LicenseCheckConditionTest.java
+++ b/sso-kit-starter/src/test/java/com/vaadin/sso/starter/LicenseCheckConditionTest.java
@@ -6,12 +6,15 @@ import org.junit.jupiter.api.Test;
 
 import com.vaadin.pro.licensechecker.LicenseException;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LicenseCheckConditionTest {
 
     private static final String VERSION = "1.0";
+
+    private static final String EXCEPTION_MESSAGE = "Programmatically fail";
 
     @Test
     public void validLicense_positiveConditionOutcome() {
@@ -27,6 +30,7 @@ public class LicenseCheckConditionTest {
         var outcome = condition.getMatchOutcome(null, null);
 
         assertFalse(outcome.isMatch());
+        assertEquals(EXCEPTION_MESSAGE, outcome.getMessage());
     }
 
     static class TestableLicenseCheckCondition extends LicenseCheckCondition {
@@ -48,7 +52,7 @@ public class LicenseCheckConditionTest {
         @Override
         void checkLicense(String version) {
             if (!shouldSucceed) {
-                throw new LicenseException("Programmatically fail");
+                throw new LicenseException(EXCEPTION_MESSAGE);
             }
         }
     }


### PR DESCRIPTION
When `LicenseCheckCondition` fails to validate the license, this will forward the `LicenseException` message to the condition outcome that will be logged by Spring.