### PR TITLE
Use custom OidcUserService to map Keycloak roles

### DIFF
--- a/sso-kit-starter/pom.xml
+++ b/sso-kit-starter/pom.xml
@@ -44,6 +44,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-oauth2-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
         </dependency>
         <dependency>

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
@@ -73,6 +73,8 @@ public class SingleSignOnConfiguration extends VaadinWebSecurity {
 
     private final BackChannelLogoutFilter backChannelLogoutFilter;
 
+    private final SingleSignOnUserService userService;
+
     /**
      * Creates an instance of this configuration bean.
      *
@@ -96,6 +98,7 @@ public class SingleSignOnConfiguration extends VaadinWebSecurity {
         this.backChannelLogoutFilter = new BackChannelLogoutFilter(
                 sessionRegistry, clientRegistrationRepository);
         this.authenticationContext = new DefaultAuthenticationContext();
+        this.userService = new SingleSignOnUserService();
     }
 
     /**
@@ -140,6 +143,8 @@ public class SingleSignOnConfiguration extends VaadinWebSecurity {
         final var maximumSessions = properties.getMaximumConcurrentSessions();
 
         http.oauth2Login(oauth2Login -> {
+            oauth2Login.userInfoEndpoint().oidcUserService(userService);
+
             // Sets Vaadin's login success handler that makes login redirects
             // compatible with Hilla endpoints. This is otherwise done
             // VaadinWebSecurity::setLoginView which is not used for OIDC.

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnUserService.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnUserService.java
@@ -1,0 +1,68 @@
+package com.vaadin.sso.starter;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.util.StringUtils;
+
+public class SingleSignOnUserService extends OidcUserService {
+
+    private static final String REALM_ACCESS_CLAIM = "realm_access";
+
+    private static final String ROLES_KEY = "roles";
+
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest)
+            throws OAuth2AuthenticationException {
+        final var user = super.loadUser(userRequest);
+        return decorateUser(user, userRequest);
+    }
+
+    protected OidcUser decorateUser(OidcUser user,
+            OidcUserRequest userRequest) {
+        final var userInfo = user.getUserInfo();
+        final var idToken = userRequest.getIdToken();
+
+        final var authorities = new HashSet<GrantedAuthority>();
+
+        authorities.addAll(user.getAuthorities());
+
+        if (userInfo.hasClaim(REALM_ACCESS_CLAIM)) {
+            final var keycloakRoles = getKeycloakRoles(userInfo, idToken);
+            authorities.addAll(keycloakRoles);
+        }
+
+        final var userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint()
+                .getUserNameAttributeName();
+
+        return StringUtils.hasText(userNameAttributeName)
+                ? new DefaultOidcUser(authorities, user.getIdToken(),
+                        user.getUserInfo(), userNameAttributeName)
+                : new DefaultOidcUser(authorities, user.getIdToken(),
+                        user.getUserInfo());
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<OidcUserAuthority> getKeycloakRoles(OidcUserInfo userInfo,
+            OidcIdToken idToken) {
+        final var realmAccessClaim = userInfo.getClaimAsMap(REALM_ACCESS_CLAIM);
+        final var roles = (Collection<String>) realmAccessClaim.get(ROLES_KEY);
+        return roles.stream()
+                .map(role -> new OidcUserAuthority(ROLE_PREFIX + role, idToken,
+                        userInfo))
+                .toList();
+    }
+}

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnUserService.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnUserService.java
@@ -3,6 +3,7 @@ package com.vaadin.sso.starter;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
@@ -63,6 +64,6 @@ public class SingleSignOnUserService extends OidcUserService {
         return roles.stream()
                 .map(role -> new OidcUserAuthority(ROLE_PREFIX + role, idToken,
                         userInfo))
-                .toList();
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
Adds a custom `OidcUserService` to map Keycloak realm-roles to the user's granted authorities.

Needs:

- [ ] JavaDoc
- [ ] Tests

Closes #47 