### PR TITLE
Use new Spring Boot 2.7  auto-configuration

### DIFF
--- a/sso-kit-starter/src/main/resources/META-INF/spring.factories
+++ b/sso-kit-starter/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.vaadin.sso.starter.SingleSignOnDefaultBeans,\
-com.vaadin.sso.starter.SingleSignOnConfiguration

--- a/sso-kit-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/sso-kit-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,2 @@
+com.vaadin.sso.starter.SingleSignOnDefaultBeans
+com.vaadin.sso.starter.SingleSignOnConfiguration


### PR DESCRIPTION
This removes the deprecated `META-INF/spring.factories` file and replaces it with the new one supported from Spring Boot 2.7.

![image](https://user-images.githubusercontent.com/851745/195549055-4c5175e1-79da-4451-b9f6-69fe53155a42.png)

Closes #25 