### PR TITLE
Add license checking for Hilla starter

### DIFF
--- a/sso-kit-core/pom.xml
+++ b/sso-kit-core/pom.xml
@@ -12,12 +12,6 @@
 
     <artifactId>sso-kit-core</artifactId>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>jakarta.servlet</groupId>

--- a/sso-kit-starter-hilla/pom.xml
+++ b/sso-kit-starter-hilla/pom.xml
@@ -14,7 +14,7 @@
     <artifactId>sso-kit-starter</artifactId>
 
     <properties>
-        <cvdl.name>vaadin-sso-kit-hilla</cvdl.name>
+        <cvdl.name>hilla-sso-kit</cvdl.name>
     </properties>
 
     <dependencies>

--- a/sso-kit-starter-hilla/pom.xml
+++ b/sso-kit-starter-hilla/pom.xml
@@ -14,9 +14,7 @@
     <artifactId>sso-kit-starter</artifactId>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <cvdl.name>vaadin-sso-kit-hilla</cvdl.name>
     </properties>
 
     <dependencies>
@@ -24,6 +22,10 @@
             <groupId>com.vaadin</groupId>
             <artifactId>sso-kit-core</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>license-checker</artifactId>
         </dependency>
         <dependency>
             <groupId>dev.hilla</groupId>
@@ -73,6 +75,23 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <CvdlName>${cvdl.name}</CvdlName>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/sso-kit-starter-hilla/src/main/java/dev/hilla/sso/starter/LicenseCheckerServiceInitListener.java
+++ b/sso-kit-starter-hilla/src/main/java/dev/hilla/sso/starter/LicenseCheckerServiceInitListener.java
@@ -31,7 +31,7 @@ public class LicenseCheckerServiceInitListener
 
     static final String VERSION_PROPERTY = "sso-kit.version";
 
-    static final String PRODUCT_NAME = "vaadin-sso-kit-hilla";
+    static final String PRODUCT_NAME = "hilla-sso-kit";
 
     @Override
     public void serviceInit(ServiceInitEvent event) {

--- a/sso-kit-starter-hilla/src/main/java/dev/hilla/sso/starter/LicenseCheckerServiceInitListener.java
+++ b/sso-kit-starter-hilla/src/main/java/dev/hilla/sso/starter/LicenseCheckerServiceInitListener.java
@@ -1,0 +1,57 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package dev.hilla.sso.starter;
+
+import java.io.IOException;
+
+import com.vaadin.flow.internal.UsageStatistics;
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinServiceInitListener;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+import static org.springframework.core.io.support.PropertiesLoaderUtils.loadAllProperties;
+
+/**
+ * Service initialization listener to verify the license.
+ *
+ * @author Vaadin Ltd
+ */
+public class LicenseCheckerServiceInitListener
+        implements VaadinServiceInitListener {
+
+    static final String PROPERTIES_RESOURCE = "sso-kit.properties";
+
+    static final String VERSION_PROPERTY = "sso-kit.version";
+
+    static final String PRODUCT_NAME = "vaadin-sso-kit-hilla";
+
+    @Override
+    public void serviceInit(ServiceInitEvent event) {
+        final var service = event.getSource();
+
+        try {
+            final var properties = loadAllProperties(PROPERTIES_RESOURCE);
+            final var version = properties.getProperty(VERSION_PROPERTY);
+
+            UsageStatistics.markAsUsed(PRODUCT_NAME, version);
+
+            // Check the license at runtime if in development mode
+            if (!service.getDeploymentConfiguration().isProductionMode()) {
+                // Using a null BuildType to allow trial licensing builds
+                // The variable is defined to avoid method signature ambiguity
+                BuildType buildType = null;
+                LicenseChecker.checkLicense(PRODUCT_NAME, version, buildType);
+            }
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/sso-kit-starter-hilla/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
+++ b/sso-kit-starter-hilla/src/main/resources/META-INF/services/com.vaadin.flow.server.VaadinServiceInitListener
@@ -1,0 +1,1 @@
+dev.hilla.sso.starter.LicenseCheckerServiceInitListener

--- a/sso-kit-starter-hilla/src/test/java/dev/hilla/sso/starter/LicenseCheckerServiceInitListenerTest.java
+++ b/sso-kit-starter-hilla/src/test/java/dev/hilla/sso/starter/LicenseCheckerServiceInitListenerTest.java
@@ -1,0 +1,93 @@
+/*-
+ * Copyright (C) 2022 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package dev.hilla.sso.starter;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.support.PropertiesLoaderUtils;
+
+import com.vaadin.flow.server.ServiceInitEvent;
+import com.vaadin.flow.server.VaadinService;
+import com.vaadin.pro.licensechecker.BuildType;
+import com.vaadin.pro.licensechecker.LicenseChecker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class LicenseCheckerServiceInitListenerTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private VaadinService service;
+
+    private MockedStatic<LicenseChecker> licenseChecker;
+
+    @BeforeEach
+    public void setup() {
+        licenseChecker = mockStatic(LicenseChecker.class);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        licenseChecker.close();
+    }
+
+    @Test
+    public void developmentMode_licenseIsCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(false);
+
+        final var version = getProperties().getProperty(
+                LicenseCheckerServiceInitListener.VERSION_PROPERTY);
+
+        // Assert version is in X.Y format
+        assertThat(version, matchesPattern("^\\d\\.\\d.*"));
+
+        final var listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        // Verify the license is checked
+        BuildType buildType = null;
+        licenseChecker.verify(() -> LicenseChecker.checkLicense(
+                LicenseCheckerServiceInitListener.PRODUCT_NAME, version,
+                buildType));
+    }
+
+    @Test
+    public void productionMode_licenseIsNotCheckedRuntime() {
+        when(service.getDeploymentConfiguration().isProductionMode())
+                .thenReturn(true);
+
+        final var listener = new LicenseCheckerServiceInitListener();
+        listener.serviceInit(new ServiceInitEvent(service));
+
+        licenseChecker.verifyNoInteractions();
+    }
+
+    private Properties getProperties() {
+        try {
+            return PropertiesLoaderUtils.loadAllProperties(
+                    LicenseCheckerServiceInitListener.PROPERTIES_RESOURCE);
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new license checker for the SSO Kit for Hilla starter. The product name used to check the license on the server is `hilla-sso-kit`.