### PR TITLE
Remove auto-configure property and condition

### DIFF
--- a/sso-kit-core/src/main/java/com/vaadin/sso/core/AbstractSingleSignOnProperties.java
+++ b/sso-kit-core/src/main/java/com/vaadin/sso/core/AbstractSingleSignOnProperties.java
@@ -48,11 +48,6 @@ public abstract class AbstractSingleSignOnProperties {
     static final int DEFAULT_MAXIMUM_SESSIONS_PER_USER = -1;
 
     /**
-     * Enables (or disables) auto-configuration.
-     */
-    private boolean autoConfigure = true;
-
-    /**
      * The route to redirect unauthorized requests to.
      */
     private String loginRoute = DEFAULT_LOGIN_ROUTE;
@@ -78,26 +73,6 @@ public abstract class AbstractSingleSignOnProperties {
      * value is -1 which means any number of concurrent sessions is allowed.
      */
     private int maximumConcurrentSessions = DEFAULT_MAXIMUM_SESSIONS_PER_USER;
-
-    /**
-     * Checks is auto-configuration of SingleSignOnConfiguration is enabled.
-     *
-     * @return true, if auto-configuration is enabled
-     */
-    public boolean isAutoConfigure() {
-        return autoConfigure;
-    }
-
-    /**
-     * Enables or disables auto-configuration of SingleSignOnConfiguration.
-     *
-     * @param autoConfigure
-     *            {@code true} to enable auto-configuration, {@code false} to
-     *            disable
-     */
-    public void setAutoConfigure(boolean autoConfigure) {
-        this.autoConfigure = autoConfigure;
-    }
 
     /**
      * Gets the login-route property.

--- a/sso-kit-starter-hilla/src/main/java/dev/hilla/sso/starter/SingleSignOnConfiguration.java
+++ b/sso-kit-starter-hilla/src/main/java/dev/hilla/sso/starter/SingleSignOnConfiguration.java
@@ -10,7 +10,6 @@
 package dev.hilla.sso.starter;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
@@ -29,7 +28,6 @@ import com.vaadin.sso.core.BackChannelLogoutFilter;
 @AutoConfiguration
 @EnableWebSecurity
 @Conditional(ClientsConfiguredCondition.class)
-@ConditionalOnProperty(name = "auto-configure", prefix = SingleSignOnProperties.PREFIX, matchIfMissing = true)
 @EnableConfigurationProperties(SingleSignOnProperties.class)
 public class SingleSignOnConfiguration extends VaadinWebSecurity {
 

--- a/sso-kit-starter-hilla/src/test/java/dev/hilla/sso/starter/SingleSignOnConfigurationTest.java
+++ b/sso-kit-starter-hilla/src/test/java/dev/hilla/sso/starter/SingleSignOnConfigurationTest.java
@@ -53,25 +53,6 @@ public class SingleSignOnConfigurationTest {
     }
 
     @Test
-    public void autoConfigureProperty_notSet_configurationEnabled() {
-        contextRunner.run(ctx -> assertThat(ctx)
-                .hasSingleBean(SingleSignOnConfiguration.class)
-                .hasSingleBean(BackChannelLogoutSubscription.class)
-                .hasSingleBean(SingleSignOnContext.class)
-                .hasSingleBean(BootstrapDataServiceListener.class));
-    }
-
-    @Test
-    public void autoConfigureProperty_isFalse_configurationDisabled() {
-        contextRunner.withPropertyValues("hilla.sso.auto-configure=false")
-                .run(ctx -> assertThat(ctx)
-                        .doesNotHaveBean(SingleSignOnConfiguration.class)
-                        .doesNotHaveBean(BackChannelLogoutSubscription.class)
-                        .doesNotHaveBean(SingleSignOnContext.class)
-                        .doesNotHaveBean(BootstrapDataServiceListener.class));
-    }
-
-    @Test
     public void clientRepository_notAvailable_configurationDisabled() {
         final var runner = new WebApplicationContextRunner().withConfiguration(
                 AutoConfigurations.of(SpringBootAutoConfiguration.class,

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
@@ -12,7 +12,6 @@ package com.vaadin.sso.starter;
 import java.util.Objects;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConfiguredCondition;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
@@ -49,7 +48,6 @@ import com.vaadin.sso.core.BackChannelLogoutFilter;
 @AutoConfiguration
 @EnableWebSecurity
 @Conditional(ClientsConfiguredCondition.class)
-@ConditionalOnProperty(name = "auto-configure", prefix = SingleSignOnProperties.PREFIX, matchIfMissing = true)
 @EnableConfigurationProperties(SingleSignOnProperties.class)
 public class SingleSignOnConfiguration extends VaadinWebSecurity {
 

--- a/sso-kit-starter/src/test/java/com/vaadin/sso/starter/SingleSignOnConfigurationTest.java
+++ b/sso-kit-starter/src/test/java/com/vaadin/sso/starter/SingleSignOnConfigurationTest.java
@@ -53,19 +53,6 @@ public class SingleSignOnConfigurationTest {
     }
 
     @Test
-    public void autoConfigureProperty_notSet_configurationEnabled() {
-        contextRunner.run(ctx -> assertThat(ctx)
-                .hasSingleBean(SingleSignOnConfiguration.class));
-    }
-
-    @Test
-    public void autoConfigureProperty_isFalse_configurationDisabled() {
-        contextRunner.withPropertyValues("vaadin.sso.auto-configure=false")
-                .run(ctx -> assertThat(ctx)
-                        .doesNotHaveBean(SingleSignOnConfiguration.class));
-    }
-
-    @Test
     public void clientRepository_notAvailable_configurationDisabled() {
         final var runner = new WebApplicationContextRunner().withConfiguration(
                 AutoConfigurations.of(SpringBootAutoConfiguration.class,


### PR DESCRIPTION
This removes the `vaadin.sso.auto-configure` Spring Boot property and the `@ConditionalOnProperty` annotation in both Flow and Hilla `SingleSignOnConfiguration` classes.

The proper way to disable auto-configuration is to use the `spring.autoconfigure.exclude` property, e.g.

```
spring.autoconfigure.exclude=com.vaadin.sso.starter.SingleSignOnConfiguration
```

Closes #86 