### PR TITLE
chore: update spring-boot and license checker version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>24.1-SNAPSHOT</flow.version>
         <hilla.version>2.1-SNAPSHOT</hilla.version>
-        <spring.boot.version>3.0.4</spring.boot.version>
+        <spring.boot.version>3.0.5</spring.boot.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.source.version>3.2.1</maven.source.version>
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>com.vaadin</groupId>
                 <artifactId>license-checker</artifactId>
-                <version>1.12.2</version>
+                <version>1.12.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/sso-kit-core/pom.xml
+++ b/sso-kit-core/pom.xml
@@ -29,22 +29,9 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
         </dependency>
-        <!-- We need to exclude json-smart and bump to 2.4.10 until a new 
-             spring version is released -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>net.minidev</groupId>
-                    <artifactId>json-smart</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.4.10</version>
         </dependency>
         <dependency>
             <groupId>jakarta.websocket</groupId>


### PR DESCRIPTION
SB 3.0.5 uses the json-smart 2.4.10, so we can remove the dependency exclusion and declaration 