### PR TITLE
exclude the json-smart and use 2.4.10

### DIFF
--- a/sso-kit-core/pom.xml
+++ b/sso-kit-core/pom.xml
@@ -25,9 +25,23 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-jose</artifactId>
         </dependency>
+        <!-- We need to exclude json-smart and bump to 2.4.10 until a new 
+             spring version is released -->
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-config</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.4.10</version>
+        </dependency>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/sso-kit-core/pom.xml
+++ b/sso-kit-core/pom.xml
@@ -42,7 +42,6 @@
             <artifactId>json-smart</artifactId>
             <version>2.4.10</version>
         </dependency>
-        </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-oauth2-client</artifactId>


### PR DESCRIPTION
the currently spring-security-config:6.0.2 is still using the vulnerable version

