### PR TITLE
Refactor user handling in SingleSignOnContext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14112,6 +14112,9 @@
         "rimraf": "^3.0.2",
         "sinon": "^15.0.2",
         "sinon-chai": "^3.7.0"
+      },
+      "peerDependencies": {
+        "lit": "^2.3.0"
       }
     },
     "sso-kit-client/node_modules/concurrently": {

--- a/sso-kit-client/package.json
+++ b/sso-kit-client/package.json
@@ -66,6 +66,9 @@
     "@hilla/frontend": "2.0.0",
     "tslib": "^2.3.1"
   },
+  "peerDependencies": {
+    "lit": "^2.3.0"
+  },
   "devDependencies": {
     "@esm-bundle/chai": "^4.3.4-fix.0",
     "@types/chai": "^4.2.22",

--- a/sso-kit-client/src/SingleSignOnContext.ts
+++ b/sso-kit-client/src/SingleSignOnContext.ts
@@ -210,7 +210,6 @@ export class SingleSignOnContext {
    */
   logout = async () => {
     await logout();
-    this.#clearSingleSignOnData();
     window.location.href = this.logoutUrl!;
   };
 
@@ -222,22 +221,6 @@ export class SingleSignOnContext {
   onBackChannelLogout(callback: LogoutCallback) {
     this.#logoutSubscriptionCallback = callback;
   }
-
-  /**
-   * Clears the authentication information.
-   */
-  #clearSingleSignOnData = () => {
-    this.authenticated = false;
-    this.roles = [];
-    this.logoutUrl = undefined;
-    this.#registrationIds = undefined;
-    this.#user = undefined;
-    this.#logoutSubscriptionCallback = undefined;
-    if (this.#logoutSubscription) {
-      this.#logoutSubscription.cancel();
-      this.#logoutSubscription = undefined;
-    }
-  };
 }
 
 export default function singleSignOnContext() {


### PR DESCRIPTION
This PR refactors the user handling in the `SingleSignOnContext` class and does some other smaller changes.

- [x] Adds a Promise function to the `SingleSignOnContext` to get the authenticated user. With this the user can await for it when rendering.
- [x] Adds a Promise function to the `SingleSignOnContext` to get the provider registration ids. Using these the user can create login URLs for the different providers.
- [x] Adds a Promise function to the `SingleSignOnContext` to fetch the single sign-on data stored in the context. With this the user can fetch the data if needed.
- [x] Removes the `clearSingleSignOnData` function as it is not needed anymore when logout is called because the logout will always redirect the user out to the provider's logout URL and after back to the post logout redirect URL which steps trigger a page reload.
- [x] Updates some JsDocs
- [x] Adds missing lit dependency

Closes #90