### PR TITLE
Add route protection

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,6 +52,7 @@ jobs:
       id: cache-node_modules
       with:
         path: sso-kit-client/node_modules
+        cache-dependency-path: sso-kit-client/package-lock.json
         key: ${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}
     - name: Install npm dependencies
       if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,8 +52,7 @@ jobs:
       id: cache-node_modules
       with:
         path: sso-kit-client/node_modules
-        cache-dependency-path: sso-kit-client/package-lock.json
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('package-lock.json') }}
+        key: ${{ runner.os }}-node_modules-${{ hashFiles('sso-kit-client/package-lock.json') }}
     - name: Install npm dependencies
       if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}
       shell: bash

--- a/sso-kit-client/core/src/AccessProps.d.ts
+++ b/sso-kit-client/core/src/AccessProps.d.ts
@@ -12,5 +12,5 @@
  * authentication is needed to access that route.
  */
 export type AccessProps = Readonly<{
-  protectedRoute?: boolean;
+  requireAuthentication?: boolean;
 }>;

--- a/sso-kit-client/core/src/AccessProps.d.ts
+++ b/sso-kit-client/core/src/AccessProps.d.ts
@@ -12,5 +12,5 @@
  * authentication is needed to access that route.
  */
 export type AccessProps = Readonly<{
-  requiresLogin?: boolean;
+  protectedRoute?: boolean;
 }>;

--- a/sso-kit-client/lit/package.json
+++ b/sso-kit-client/lit/package.json
@@ -55,7 +55,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@hilla/frontend": "2.0.0",
+    "@hilla/frontend": "2.0.5",
+    "@vaadin/router": "1.7.5",
     "tslib": "^2.3.1"
   },
   "peerDependencies": {

--- a/sso-kit-client/lit/src/SingleSignOnContext.ts
+++ b/sso-kit-client/lit/src/SingleSignOnContext.ts
@@ -245,13 +245,16 @@ export class SingleSignOnContext {
    * {@link AccessProps#protectedRoute} property.
    *
    * @param routes the routes to check if they need to be protected
+   * @param redirectPath the path to redirect to when the user is not
+   *                     authenticated, the default value is the 'ssologin' path
+   *                     which redirects the user to the provider's login page
    * @returns the {@param routes} with the protected routes, if any
    */
-  protectRoutes = (routes: ViewRoute[]): ViewRoute[] => {
+  protectRoutes = (routes: ViewRoute[], redirectPath?: string): ViewRoute[] => {
     const allRoutes: ViewRoute[] = this.collectRoutes(routes);
     allRoutes.forEach((route) => {
       if (route.protectedRoute) {
-        this.protectRoute(route);
+        this.protectRoute(route, redirectPath);
       }
     });
 
@@ -266,14 +269,14 @@ export class SingleSignOnContext {
     return routes;
   };
 
-  private protectRoute = (route: ViewRoute): void => {
+  private protectRoute = (route: ViewRoute, redirectPath?: string): void => {
     const routeAction: ActionFn | undefined = route.action;
     route.action = (
       _context: Context,
       _commands: Commands
     ): ActionResult | Promise<ActionResult> => {
       if (!this.hasAccess(route)) {
-        return _commands.redirect("ssologin");
+        return _commands.redirect(redirectPath ? redirectPath : 'ssologin');
       }
       return routeAction?.apply(null, [_context, _commands]);
     };

--- a/sso-kit-client/lit/src/SingleSignOnContext.ts
+++ b/sso-kit-client/lit/src/SingleSignOnContext.ts
@@ -203,7 +203,7 @@ export class SingleSignOnContext {
    * @returns true if the user has access to the given route, false otherwise
    */
   hasAccess = (route: AccessProps) => {
-    return !route.protectedRoute || this.authenticated;
+    return !route.requireAuthentication || this.authenticated;
   };
 
   /**
@@ -241,8 +241,8 @@ export class SingleSignOnContext {
   }
 
   /**
-   * Adds protection to view routes which are marked as protected with the
-   * {@link AccessProps#protectedRoute} property.
+   * Adds protection to view routes which require authentication by using the
+   * {@link AccessProps#requireAuthentication} property.
    *
    * @param routes the routes to check if they need to be protected
    * @param redirectPath the path to redirect to when the user is not
@@ -253,7 +253,7 @@ export class SingleSignOnContext {
   protectRoutes = (routes: ViewRoute[], redirectPath?: string): ViewRoute[] => {
     const allRoutes: ViewRoute[] = this.collectRoutes(routes);
     allRoutes.forEach((route) => {
-      if (route.protectedRoute) {
+      if (route.requireAuthentication) {
         this.protectRoute(route, redirectPath);
       }
     });

--- a/sso-kit-client/lit/src/SingleSignOnContext.ts
+++ b/sso-kit-client/lit/src/SingleSignOnContext.ts
@@ -9,7 +9,13 @@
  */
 import type { Subscription } from "@hilla/frontend";
 import { logout } from "@hilla/frontend";
-import type { ActionFn, ActionResult, Route } from "@vaadin/router";
+import type {
+  ActionFn,
+  ActionResult,
+  Commands,
+  Context,
+  Route,
+} from "@vaadin/router";
 import type { AccessProps } from "../../core/src/AccessProps.js";
 import type { SingleSignOnData } from "../../core/src/SingleSignOnData.js";
 import type { User } from "../../core/src/User.js";
@@ -252,7 +258,7 @@ export class SingleSignOnContext {
     routes.push({
       path: "ssologin",
       component: "ssologin",
-      action: async (_context, _commands) => {
+      action: async (_context: Context, _commands: Commands) => {
         window.location.href = this.loginUrl;
         return undefined;
       },
@@ -263,8 +269,8 @@ export class SingleSignOnContext {
   private protectRoute = (route: ViewRoute): void => {
     const routeAction: ActionFn | undefined = route.action;
     route.action = (
-      _context,
-      _commands
+      _context: Context,
+      _commands: Commands
     ): ActionResult | Promise<ActionResult> => {
       if (!this.hasAccess(route)) {
         return _commands.redirect("ssologin");

--- a/sso-kit-client/lit/src/SingleSignOnContext.ts
+++ b/sso-kit-client/lit/src/SingleSignOnContext.ts
@@ -22,13 +22,10 @@ import type { User } from "../../core/src/User.js";
 import { EndpointImportError } from "../../core/src/EndpointImportError.js";
 
 /**
- * Definition of the Route extended with {@link AccessProps} and
- * children routes property, used to define a protected route.
+ * Definition of the Route extended with {@link AccessProps},
+ * used to define a protected route.
  */
-export type ProtectedRoute = Route &
-  AccessProps & {
-    children?: ProtectedRoute[];
-  };
+export type ProtectedRoute = Route & AccessProps;
 
 /**
  * Definition of the back-channel logout endpoint subscription message.
@@ -294,7 +291,9 @@ export class SingleSignOnContext {
     routes.forEach((route) => {
       allRoutes.push(route);
       if (route.children !== undefined) {
-        allRoutes.push(...this.collectRoutes(route.children));
+        allRoutes.push(
+          ...this.collectRoutes(route.children as ProtectedRoute[])
+        );
       }
     });
     return allRoutes;

--- a/sso-kit-client/lit/src/SingleSignOnContext.ts
+++ b/sso-kit-client/lit/src/SingleSignOnContext.ts
@@ -276,7 +276,10 @@ export class SingleSignOnContext {
       _commands: Commands
     ): ActionResult | Promise<ActionResult> => {
       if (!this.hasAccess(route)) {
-        return _commands.redirect(redirectPath ? redirectPath : 'ssologin');
+        if (redirectPath === undefined) {
+          redirectPath = "ssologin";
+        }
+        return _commands.redirect(redirectPath);
       }
       return routeAction?.apply(null, [_context, _commands]);
     };

--- a/sso-kit-client/lit/src/SingleSignOnContext.ts
+++ b/sso-kit-client/lit/src/SingleSignOnContext.ts
@@ -22,14 +22,12 @@ import type { User } from "../../core/src/User.js";
 import { EndpointImportError } from "../../core/src/EndpointImportError.js";
 
 /**
- * Definition of the route extended with {@link AccessProps} used to define a
- * view route.
+ * Definition of the Route extended with {@link AccessProps} and
+ * children routes property, used to define a protected route.
  */
-type ViewRoute = Route &
+export type ProtectedRoute = Route &
   AccessProps & {
-    title?: string;
-    icon?: string;
-    children?: ViewRoute[];
+    children?: ProtectedRoute[];
   };
 
 /**
@@ -250,8 +248,11 @@ export class SingleSignOnContext {
    *                     which redirects the user to the provider's login page
    * @returns the {@param routes} with the protected routes, if any
    */
-  protectRoutes = (routes: ViewRoute[], redirectPath?: string): ViewRoute[] => {
-    const allRoutes: ViewRoute[] = this.collectRoutes(routes);
+  protectRoutes = (
+    routes: ProtectedRoute[],
+    redirectPath?: string
+  ): Route[] => {
+    const allRoutes: ProtectedRoute[] = this.collectRoutes(routes);
     allRoutes.forEach((route) => {
       if (route.requireAuthentication) {
         this.protectRoute(route, redirectPath);
@@ -269,7 +270,10 @@ export class SingleSignOnContext {
     return routes;
   };
 
-  private protectRoute = (route: ViewRoute, redirectPath?: string): void => {
+  private protectRoute = (
+    route: ProtectedRoute,
+    redirectPath?: string
+  ): void => {
     const routeAction: ActionFn | undefined = route.action;
     route.action = (
       _context: Context,
@@ -285,8 +289,8 @@ export class SingleSignOnContext {
     };
   };
 
-  private collectRoutes = (routes: ViewRoute[]): ViewRoute[] => {
-    const allRoutes: ViewRoute[] = [];
+  private collectRoutes = (routes: ProtectedRoute[]): ProtectedRoute[] => {
+    const allRoutes: ProtectedRoute[] = [];
     routes.forEach((route) => {
       allRoutes.push(route);
       if (route.children !== undefined) {

--- a/sso-kit-client/lit/src/index.ts
+++ b/sso-kit-client/lit/src/index.ts
@@ -13,6 +13,7 @@ import { SingleSignOnContext } from "./SingleSignOnContext.js";
 export * from "./SingleSignOnContext.js";
 export { EndpointImportError } from "../../core/src/EndpointImportError.js";
 export type { AccessProps } from "../../core/src/AccessProps.js";
+export type { ProtectedRoute } from "./SingleSignOnContext.js";
 export type { User } from "../../core/src/User.js";
 
 declare global {

--- a/sso-kit-client/package-lock.json
+++ b/sso-kit-client/package-lock.json
@@ -64,7 +64,8 @@
       "version": "2.1.0",
       "license": "See license in LICENSE file",
       "dependencies": {
-        "@hilla/frontend": "2.0.0",
+        "@hilla/frontend": "2.0.5",
+        "@vaadin/router": "1.7.5",
         "tslib": "^2.3.1"
       },
       "devDependencies": {
@@ -88,6 +89,20 @@
         "rimraf": "^3.0.2",
         "sinon": "^15.0.2",
         "sinon-chai": "^3.7.0"
+      },
+      "peerDependencies": {
+        "lit": "^2.3.0"
+      }
+    },
+    "lit/node_modules/@hilla/frontend": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@hilla/frontend/-/frontend-2.0.5.tgz",
+      "integrity": "sha512-LRlBa1/G5d8Gp/nskOrJcCMGkZrKo+wbLEJ/HGFwkx8J9DTGQcg1ua1gX6YIB9d8ryB/byDX8fETjpBYy/+tYQ==",
+      "dependencies": {
+        "@vaadin/common-frontend": "^0.0.12",
+        "a-atmosphere-javascript": "3.1.3-2",
+        "js-cookie": "^3.0.1",
+        "rimraf": "^3.0.2"
       },
       "peerDependencies": {
         "lit": "^2.3.0"
@@ -3414,6 +3429,37 @@
       "integrity": "sha512-3tsrwTgkO56jHbb+dwVz2LuZpinSFnXSf4Wmzepo5nYyaavkXdbRUaigkjmwpZiD7r8yD1IR6NkFtqxFEtJFzQ==",
       "dependencies": {
         "lit": "^2.0.0-rc.2"
+      }
+    },
+    "node_modules/@vaadin/router": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@vaadin/router/-/router-1.7.5.tgz",
+      "integrity": "sha512-uRN3vd1ihgd596bF/NMZqpgxau0nlvIc0/JDd1EwStFNbZID/xIVse5LXdQhIyUKLmSl4T0GeCQK505xerWX0w==",
+      "dependencies": {
+        "@vaadin/vaadin-usage-statistics": "^2.1.0",
+        "path-to-regexp": "2.4.0"
+      }
+    },
+    "node_modules/@vaadin/router/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w=="
+    },
+    "node_modules/@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.6.tgz",
+      "integrity": "sha512-N6a5nLT/ytEUlpPo+nvdCKIGoyNjPsj3rzPGvGYK8x9Ceg76OTe1xI/GtN71mRW9e2HUScR0kCNOkl1Z63YDjw=="
+    },
+    "node_modules/@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.2.tgz",
+      "integrity": "sha512-xKs1PvRfTXsG0eWWcImLXWjv7D+f1vfoIvovppv6pZ5QX8xgcxWUdNgERlOOdGt3CTuxQXukTBW3+Qfva+OXSg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -7867,6 +7913,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/sso-kit-client/react/src/SingleSignOnContext.ts
+++ b/sso-kit-client/react/src/SingleSignOnContext.ts
@@ -185,7 +185,7 @@ export class SingleSignOnContext {
    * @returns true if the user has access to the given route, false otherwise
    */
   hasAccess = (route: AccessProps) => {
-    return !route.protectedRoute || this.authenticated;
+    return !route.requireAuthentication || this.authenticated;
   };
 
   /**

--- a/sso-kit-client/react/src/SingleSignOnContext.ts
+++ b/sso-kit-client/react/src/SingleSignOnContext.ts
@@ -185,7 +185,7 @@ export class SingleSignOnContext {
    * @returns true if the user has access to the given route, false otherwise
    */
   hasAccess = (route: AccessProps) => {
-    return !route.requiresLogin || this.authenticated;
+    return !route.protectedRoute || this.authenticated;
   };
 
   /**


### PR DESCRIPTION
## Description

Adds route protection to sso-kit-client-lit package.
This change introduces the `SingleSignOnContext.protectRoutes` function which can be used to protect the view routes if any of them is marked with the `protectedRoute: true` property. After the route is protected the route can be accessed only if the user is authenticated otherwise will be redirected to the provider's login page.

- [x] Fixes #89 for sso-kit-client-lit package part
