### PR TITLE
Update demo application

### DIFF
--- a/sso-kit-demo/src/main/java/com/vaadin/sso/demo/DemoApplication.java
+++ b/sso-kit-demo/src/main/java/com/vaadin/sso/demo/DemoApplication.java
@@ -13,7 +13,7 @@ import com.vaadin.flow.theme.Theme;
  */
 @Theme("sso-kit-demo")
 @NpmPackage(value = "line-awesome", version = "1.3.0")
-@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.0.6")
+@NpmPackage(value = "@vaadin-component-factory/vcf-nav", version = "1.1.3")
 @SpringBootApplication
 public class DemoApplication extends SpringBootServletInitializer
         implements AppShellConfigurator {

--- a/sso-kit-demo/src/main/resources/application.yml
+++ b/sso-kit-demo/src/main/resources/application.yml
@@ -1,5 +1,2 @@
 server:
   port: ${PORT:8080}
-vaadin:
-  sso:
-    auto-configure: true


### PR DESCRIPTION
- Updates `@vaadin-component-factory/vcf-nav` version to `1.1.3` to make it run with Flow 24.4
- Removes deprecated configuration property