### PR TITLE
Upgrade spring-boot and spring-security versions in 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <flow.version>23.3-SNAPSHOT</flow.version>
-        <spring.boot.version>2.7.4</spring.boot.version>
+        <spring.boot.version>2.7.18</spring.boot.version>
+        <spring.security.version>5.8.9</spring.security.version>
         <maven.jar.version>3.3.0</maven.jar.version>
         <maven.source.version>3.2.1</maven.source.version>
         <maven.javadoc.version>3.4.1</maven.javadoc.version>
@@ -54,6 +55,13 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.security</groupId>
+                <artifactId>spring-security-bom</artifactId>
+                <version>${spring.security.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
Upgrades spring-boot to 2.7.18 and spring-security to 5.8.9 versions in 1.0.

Closes #138 