### PR TITLE
Rename Hilla groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,8 +73,8 @@
                 <version>${flow.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.vaadin.hilla</groupId>
-                <artifactId>endpoint</artifactId>
+                <groupId>com.vaadin</groupId>
+                <artifactId>hilla-endpoint</artifactId>
                 <version>${hilla.version}</version>
             </dependency>
             <dependency>

--- a/sso-kit-starter-hilla/pom.xml
+++ b/sso-kit-starter-hilla/pom.xml
@@ -7,12 +7,10 @@
         <artifactId>sso-kit</artifactId>
         <version>3.0-SNAPSHOT</version>
     </parent>
-    <version>3.0-SNAPSHOT</version>
 
     <name>SSO Kit Starter for Hilla</name>
 
-    <groupId>com.vaadin.hilla</groupId>
-    <artifactId>sso-kit-starter</artifactId>
+    <artifactId>sso-kit-starter-hilla</artifactId>
 
     <properties>
         <cvdl.name>hilla-sso-kit</cvdl.name>
@@ -28,14 +26,14 @@
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring</artifactId>
             <scope>provided</scope>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>license-checker</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.vaadin.hilla</groupId>
-            <artifactId>endpoint</artifactId>
+            <groupId>com.vaadin</groupId>
+            <artifactId>hilla-endpoint</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This renames the `groupId` for Hilla packages and also catches up with changes done in https://github.com/vaadin/hilla/commit/a9e0c36f94ae1412c1e2910bced7cc0c8001e229

Breaking changes:
- the kit starter for Hilla has been renamed from
  `com.vaadin.hilla:sso-kit-starter`
  to
  `com.vaadin:sso-kit-starter-hilla`

We might not even need a separate module for Hilla now.