### PR TITLE
Deprecate custom Back-Channel Logout filter

### DIFF
--- a/sso-kit-core/src/main/java/com/vaadin/sso/core/AbstractSingleSignOnProperties.java
+++ b/sso-kit-core/src/main/java/com/vaadin/sso/core/AbstractSingleSignOnProperties.java
@@ -37,7 +37,10 @@ public abstract class AbstractSingleSignOnProperties {
      * client registration-id: {@code registrationId}.
      *
      * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+     * @deprecated Use built-in Spring Security support for OpenID Connect
+     *             Back-Channel Logout
      */
+    @Deprecated(since = "3.1", forRemoval = true)
     public static final String DEFAULT_BACKCHANNEL_LOGOUT_ROUTE = "/logout/back-channel/{"
             + BackChannelLogoutFilter.REGISTRATION_ID_URI_VARIABLE_NAME + "}";
 

--- a/sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java
+++ b/sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java
@@ -39,7 +39,10 @@ import org.springframework.web.filter.GenericFilterBean;
  * @author Vaadin Ltd
  * @since 1.0
  * @see https://openid.net/specs/openid-connect-backchannel-1_0.html
+ * @deprecated Use built-in Spring Security support for OpenID Connect
+ *             Back-Channel Logout
  */
+@Deprecated(since = "3.1", forRemoval = true)
 public class BackChannelLogoutFilter extends GenericFilterBean {
 
     /* Value defined by the specification */

--- a/sso-kit-core/src/main/java/com/vaadin/sso/core/OidcLogoutTokenValidator.java
+++ b/sso-kit-core/src/main/java/com/vaadin/sso/core/OidcLogoutTokenValidator.java
@@ -35,7 +35,10 @@ import org.springframework.util.CollectionUtils;
  * @author Vaadin Ltd
  * @since 1.0
  * @see https://openid.net/specs/openid-connect-backchannel-1_0.html#Validation
+ * @deprecated Use built-in Spring Security support for OpenID Connect
+ *             Back-Channel Logout
  */
+@Deprecated(since = "3.1", forRemoval = true)
 public final class OidcLogoutTokenValidator
         implements OAuth2TokenValidator<Jwt> {
 

--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/SingleSignOnConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.boot.autoconfigure.security.oauth2.client.ClientsConf
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.session.SessionRegistry;
@@ -158,6 +159,8 @@ public class SingleSignOnConfiguration extends VaadinWebSecurity {
             // Disable CSRF for Back-Channel logout requests
             final var matcher = backChannelLogoutFilter.getRequestMatcher();
             http.csrf().ignoringRequestMatchers(matcher);
+        } else {
+            http.oidcLogout().backChannel(Customizer.withDefaults());
         }
     }
 }


### PR DESCRIPTION
This deprecates SSO Kit custom Back-Channel Logout support in favor of Spring Security build-in support that is now enabled by default if the app is not using the custom one.