### PR TITLE
add name tag to sso-kit-keycloak

### DIFF
--- a/sso-kit-keycloak/pom.xml
+++ b/sso-kit-keycloak/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>sso-kit-keycloak</artifactId>
     <packaging>pom</packaging>
+    <name>SSO Kit Keycloak</name>
 
     <modules>
         <module>sso-kit-keycloak-lumo</module>


### PR DESCRIPTION
name tag is needed for central portal release