### PR TITLE
fix: Add no-arg public CTOR to LicenseCheckerServiceInitListener

### DIFF
--- a/sso-kit-starter/src/main/java/com/vaadin/sso/starter/LicenseCheckerServiceInitListener.java
+++ b/sso-kit-starter/src/main/java/com/vaadin/sso/starter/LicenseCheckerServiceInitListener.java
@@ -42,8 +42,9 @@ public class LicenseCheckerServiceInitListener
     }
 
     /**
-     * Initialises a license checking mechanism for SSO Kit using it's product name and current version.
-     */        
+     * Initialises a license checking mechanism for SSO Kit using it's product
+     * name and current version.
+     */
     public LicenseCheckerServiceInitListener() {
         super(PRODUCT_NAME, PRODUCT_VERSION);
     }


### PR DESCRIPTION
Prevents Spring DI errors like
```
java.util.ServiceConfigurationError: com.vaadin.flow.server.VaadinServiceInitListener: com.vaadin.sso.starter.LicenseCheckerServiceInitListener Unable to get public no-arg constructor
Caused by: java.lang.NoSuchMethodException: com.vaadin.sso.starter.LicenseCheckerServiceInitListener.<init>()
        at java.base/java.lang.Class.getConstructor0(Class.java:3761) ~[na:na]
2025-09-01T13:27:39.000+03:00 ERROR 65877 --- [in-dev-server-1] c.v.f.s.frontend.TaskUpdatePackages      : Error when running `npm install`
java.lang.InterruptedException: null
org.springframework.context.ApplicationContextException: Failed to start bean 'webServerStartStop
```
because no public no-args constructor found.