### PR TITLE
ci: add integration test workflow with Keycloak login

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,105 @@
+name: Integration Test
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+  merge_group:
+permissions:
+  contents: read
+concurrency:
+  group: it-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+env:
+  JAVA_VERSION: '21'
+  APP_URL: http://localhost:8080
+  KEYCLOAK_URL: http://localhost:8180
+jobs:
+  integration-test:
+    timeout-minutes: 45
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: 'temurin'
+          cache: 'maven'
+      - name: Set TB license
+        env:
+          TB_LICENSE: ${{ secrets.TB_LICENSE }}
+        run: |
+          mkdir -p ~/.vaadin/
+          echo '{"username":"'$(echo "$TB_LICENSE" | cut -d / -f1)'","proKey":"'$(echo "$TB_LICENSE" | cut -d / -f2)'"}' > ~/.vaadin/proKey
+      - name: Build starter
+        run: mvn install -B -e -ntp -pl :sso-kit-starter -am -DskipTests
+      - name: Build demo jar
+        run: mvn package -B -e -ntp -pl :sso-kit-demo -Pproduction -DskipTests
+      - name: Start Keycloak
+        working-directory: sso-kit-demo
+        run: docker compose up -d
+      - name: Wait for Keycloak
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf "${KEYCLOAK_URL}/realms/sso-kit-demo/.well-known/openid-configuration" > /dev/null; then
+              echo "Keycloak is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Keycloak did not become ready in time"
+          docker compose -f sso-kit-demo/docker-compose.yml logs
+          exit 1
+      - name: Start demo application
+        run: |
+          APP_JAR=$(find sso-kit-demo/target -maxdepth 1 -name 'sso-kit-demo-*.jar' \! -name '*-sources.jar' \! -name '*-javadoc.jar' | head -1)
+          if [ -z "$APP_JAR" ]; then
+            echo "Could not locate demo jar under sso-kit-demo/target"
+            ls -la sso-kit-demo/target || true
+            exit 1
+          fi
+          echo "Launching $APP_JAR"
+          nohup java -jar "$APP_JAR" > app.log 2>&1 &
+          echo "APP_PID=$!" >> "$GITHUB_ENV"
+      - name: Wait for demo application
+        run: |
+          for i in $(seq 1 90); do
+            if curl -sf -o /dev/null "${APP_URL}"; then
+              echo "App is ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "App did not become ready in time"
+          tail -n 200 app.log || true
+          exit 1
+      - name: Install Playwright browsers
+        run: npx --yes playwright@1.52.0 install chromium --with-deps
+      - name: Run integration tests
+        run: |
+          mvn failsafe:integration-test failsafe:verify -B -e -ntp \
+            -pl :sso-kit-demo \
+            -Pintegration-test \
+            -Dapp.url=${APP_URL}
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== Demo app log (tail) ==="
+          tail -n 500 app.log || true
+          echo "=== docker ps ==="
+          docker ps -a
+          echo "=== Keycloak logs ==="
+          docker compose -f sso-kit-demo/docker-compose.yml logs keycloak || true
+      - name: Stop demo application
+        if: always()
+        run: |
+          if [ -n "${APP_PID:-}" ]; then
+            kill "${APP_PID}" 2>/dev/null || true
+          fi
+      - name: Stop Keycloak
+        if: always()
+        working-directory: sso-kit-demo
+        run: docker compose down -v

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Integration Test
 on:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
     branches: [main]
   workflow_dispatch:
@@ -18,6 +18,7 @@ env:
   KEYCLOAK_URL: http://localhost:8180
 jobs:
   integration-test:
+    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -34,10 +34,8 @@ jobs:
         run: |
           mkdir -p ~/.vaadin/
           echo '{"username":"'$(echo "$TB_LICENSE" | cut -d / -f1)'","proKey":"'$(echo "$TB_LICENSE" | cut -d / -f2)'"}' > ~/.vaadin/proKey
-      - name: Build starter
-        run: mvn install -B -e -ntp -pl :sso-kit-starter -am -DskipTests
       - name: Build demo jar
-        run: mvn package -B -e -ntp -pl :sso-kit-demo -Pproduction -DskipTests
+        run: mvn package -B -e -ntp -pl :sso-kit-demo -am -Pproduction -DskipTests
       - name: Start Keycloak
         working-directory: sso-kit-demo
         run: docker compose up -d
@@ -55,9 +53,9 @@ jobs:
           exit 1
       - name: Start demo application
         run: |
-          APP_JAR=$(find sso-kit-demo/target -maxdepth 1 -name 'sso-kit-demo-*.jar' \! -name '*-sources.jar' \! -name '*-javadoc.jar' | head -1)
-          if [ -z "$APP_JAR" ]; then
-            echo "Could not locate demo jar under sso-kit-demo/target"
+          APP_JAR=sso-kit-demo/target/$(mvn -pl :sso-kit-demo -q help:evaluate -DforceStdout -Dexpression=project.build.finalName).jar
+          if [ ! -f "$APP_JAR" ]; then
+            echo "Could not locate demo jar at $APP_JAR"
             ls -la sso-kit-demo/target || true
             exit 1
           fi
@@ -84,15 +82,21 @@ jobs:
             -pl :sso-kit-demo \
             -Pintegration-test \
             -Dapp.url=${APP_URL}
-      - name: Collect diagnostics on failure
+      - name: Collect Keycloak logs
         if: failure()
-        run: |
-          echo "=== Demo app log (tail) ==="
-          tail -n 500 app.log || true
-          echo "=== docker ps ==="
-          docker ps -a
-          echo "=== Keycloak logs ==="
-          docker compose -f sso-kit-demo/docker-compose.yml logs keycloak || true
+        run: docker compose -f sso-kit-demo/docker-compose.yml logs keycloak > keycloak.log 2>&1 || true
+      - name: Upload diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-diagnostics
+          path: |
+            app.log
+            keycloak.log
+            sso-kit-demo/target/failsafe-reports/**
+            sso-kit-demo/target/playwright-traces/**
+          if-no-files-found: ignore
+          retention-days: 14
       - name: Stop demo application
         if: always()
         run: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,10 +34,11 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Set TB License
+      env:
+        TB_LICENSE: ${{ secrets.TB_LICENSE }}
       run: |
-        TB_LICENSE=${{secrets.TB_LICENSE}}
         mkdir -p ~/.vaadin/
-        echo '{"username":"'`echo $TB_LICENSE | cut -d / -f1`'","proKey":"'`echo $TB_LICENSE | cut -d / -f2`'"}' > ~/.vaadin/proKey
+        echo '{"username":"'$(echo "$TB_LICENSE" | cut -d / -f1)'","proKey":"'$(echo "$TB_LICENSE" | cut -d / -f2)'"}' > ~/.vaadin/proKey
     - name: Run Java tests
       run: mvn -ntp -B verify
     - name: Setup Node.js

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
   </modules>
 
   <properties>
-    <flow.version>25.0-SNAPSHOT</flow.version>
-    <hilla.version>25.0-SNAPSHOT</hilla.version>
+    <flow.version>25.1-SNAPSHOT</flow.version>
+    <hilla.version>25.1-SNAPSHOT</hilla.version>
     <vaadin.license.checker.version>3.0.1</vaadin.license.checker.version>
 
     <maven.compiler.release>21</maven.compiler.release>

--- a/sso-kit-demo/pom.xml
+++ b/sso-kit-demo/pom.xml
@@ -100,6 +100,18 @@
       <artifactId>spring-boot-devtools</artifactId>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>com.microsoft.playwright</groupId>
+      <artifactId>playwright</artifactId>
+      <version>1.52.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -151,6 +163,32 @@
                   <goal>build-frontend</goal>
                 </goals>
                 <phase>compile</phase>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>integration-test</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <version>${maven.surefire.version}</version>
+            <configuration>
+              <systemPropertyVariables>
+                <app.url>${app.url}</app.url>
+              </systemPropertyVariables>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
               </execution>
             </executions>
           </plugin>

--- a/sso-kit-demo/src/main/java/com/vaadin/sso/demo/view/ProfileView.java
+++ b/sso-kit-demo/src/main/java/com/vaadin/sso/demo/view/ProfileView.java
@@ -14,6 +14,9 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
 import com.vaadin.flow.component.avatar.Avatar;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.H3;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.textfield.EmailField;
 import com.vaadin.flow.component.textfield.TextField;
@@ -47,6 +50,8 @@ public class ProfileView extends VerticalLayout {
             emailField.setWidthFull();
             nameField.setReadOnly(true);
             emailField.setReadOnly(true);
+            nameField.setId("name");
+            emailField.setId("email");
 
             avatar.setName(fullName);
             nameField.setValue(fullName);
@@ -56,6 +61,16 @@ public class ProfileView extends VerticalLayout {
             }
 
             add(avatar, nameField, emailField);
+
+            H3 rolesTitle = new H3("Roles");
+            Div roles = new Div();
+            roles.setId("roles");
+            authContext.getGrantedAuthorities().forEach(authority -> {
+                Span span = new Span(authority.getAuthority());
+                span.addClassName("role");
+                roles.add(span);
+            });
+            add(rolesTitle, roles);
         });
 
         add(new Button("Logout", click -> authContext.logout()));

--- a/sso-kit-demo/src/test/java/com/vaadin/sso/demo/it/LoginIT.java
+++ b/sso-kit-demo/src/test/java/com/vaadin/sso/demo/it/LoginIT.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+
+package com.vaadin.sso.demo.it;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.assertions.LocatorAssertions;
+import com.microsoft.playwright.junit.UsePlaywright;
+import com.microsoft.playwright.options.WaitUntilState;
+import org.junit.jupiter.api.Test;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+@UsePlaywright
+class LoginIT {
+
+    static final String APP_URL = System.getProperty("app.url",
+            "http://localhost:8080");
+
+    private static final LocatorAssertions.ContainsTextOptions SLOW_CONTAINS = new LocatorAssertions.ContainsTextOptions()
+            .setTimeout(30_000);
+
+    private static final LocatorAssertions.HasValueOptions SLOW_VALUE = new LocatorAssertions.HasValueOptions()
+            .setTimeout(30_000);
+
+    private static final LocatorAssertions.IsVisibleOptions SLOW_VISIBLE = new LocatorAssertions.IsVisibleOptions()
+            .setTimeout(30_000);
+
+    @Test
+    void userLoginShowsUserIdentityAndRoles(Page page) {
+        loginAs(page, "user", "user");
+
+        assertThat(page.locator("vaadin-text-field#name input"))
+                .hasValue("John Doe", SLOW_VALUE);
+        assertThat(page.locator("vaadin-email-field#email input"))
+                .hasValue("user@example.com", SLOW_VALUE);
+
+        Locator roles = page.locator("#roles");
+        assertThat(roles).containsText("ROLE_user", SLOW_CONTAINS);
+        assertThat(roles).containsText("view-profile", SLOW_CONTAINS);
+        assertThat(roles).not().containsText("ROLE_admin");
+        assertThat(roles).not().containsText("manage-users");
+    }
+
+    @Test
+    void adminLoginShowsAdminIdentityAndRoles(Page page) {
+        loginAs(page, "admin", "admin");
+
+        assertThat(page.locator("vaadin-text-field#name input"))
+                .hasValue("Jane Doe", SLOW_VALUE);
+        assertThat(page.locator("vaadin-email-field#email input"))
+                .hasValue("admin@example.com", SLOW_VALUE);
+
+        Locator roles = page.locator("#roles");
+        assertThat(roles).containsText("ROLE_user", SLOW_CONTAINS);
+        assertThat(roles).containsText("ROLE_admin", SLOW_CONTAINS);
+        assertThat(roles).containsText("view-profile", SLOW_CONTAINS);
+        assertThat(roles).containsText("manage-users", SLOW_CONTAINS);
+    }
+
+    private void loginAs(Page page, String username, String password) {
+        page.navigate(APP_URL + "/profile", new Page.NavigateOptions()
+                .setWaitUntil(WaitUntilState.DOMCONTENTLOADED));
+
+        // Demo's LoginView shows a single "Login with Keycloak" anchor
+        // that points at Spring Security's /oauth2/authorization/keycloak.
+        page.locator("a[href*='oauth2/authorization/keycloak']").click();
+
+        // Keycloak login form (stable ids across 20-26).
+        page.locator("#username").fill(username);
+        page.locator("#password").fill(password);
+        page.locator("#kc-login").click();
+
+        // Back on the app — wait for the profile page to bootstrap. Spring
+        // Security may append a `?continue` query param on the redirect, so
+        // wait for the view's name field to materialize rather than for an
+        // exact URL match.
+        assertThat(page.locator("vaadin-text-field#name input"))
+                .isVisible(SLOW_VISIBLE);
+    }
+}

--- a/sso-kit-demo/src/test/java/com/vaadin/sso/demo/it/LoginIT.java
+++ b/sso-kit-demo/src/test/java/com/vaadin/sso/demo/it/LoginIT.java
@@ -8,12 +8,20 @@
 
 package com.vaadin.sso.demo.it;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Tracing;
 import com.microsoft.playwright.assertions.LocatorAssertions;
 import com.microsoft.playwright.junit.UsePlaywright;
 import com.microsoft.playwright.options.WaitUntilState;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
 
@@ -23,6 +31,9 @@ class LoginIT {
     static final String APP_URL = System.getProperty("app.url",
             "http://localhost:8080");
 
+    private static final Path TRACE_DIR = Paths.get("target",
+            "playwright-traces");
+
     private static final LocatorAssertions.ContainsTextOptions SLOW_CONTAINS = new LocatorAssertions.ContainsTextOptions()
             .setTimeout(30_000);
 
@@ -31,6 +42,21 @@ class LoginIT {
 
     private static final LocatorAssertions.IsVisibleOptions SLOW_VISIBLE = new LocatorAssertions.IsVisibleOptions()
             .setTimeout(30_000);
+
+    @BeforeEach
+    void startTrace(BrowserContext context) {
+        context.tracing().start(new Tracing.StartOptions().setScreenshots(true)
+                .setSnapshots(true).setSources(true));
+    }
+
+    @AfterEach
+    void stopTrace(BrowserContext context, TestInfo testInfo) {
+        String name = testInfo.getTestMethod().map(m -> m.getName())
+                .orElse("trace");
+        Path target = TRACE_DIR.resolve(name + ".zip");
+        target.getParent().toFile().mkdirs();
+        context.tracing().stop(new Tracing.StopOptions().setPath(target));
+    }
 
     @Test
     void userLoginShowsUserIdentityAndRoles(Page page) {


### PR DESCRIPTION
## Summary
- New GitHub Actions workflow that builds the demo into a production Spring Boot jar, starts Keycloak via the existing `sso-kit-demo/docker-compose.yml`, and runs Java Playwright tests that drive the full OIDC login flow for both demo users
- `ProfileView` now renders the authenticated user's granted authorities behind a stable `#roles` locator so tests can assert identity and role mapping end-to-end
- Tests via `failsafe:integration-test failsafe:verify` so the prebuilt production jar is not silently rebuilt in dev mode by the default lifecycle
- Side fixes: `maven.yml` reads `TB_LICENSE` through an env var (not inlined), and `flow.version` bumped to `25.1-SNAPSHOT` to match the published `25.1.0-rc1` client

## Test plan
- [x] Local smoke test green end-to-end on Temurin 21 against Keycloak 26.1 from `docker-compose.yml`
- [x] `LoginIT#userLoginShowsUserIdentityAndRoles` asserts name "John Doe", email, `ROLE_user`, `view-profile`, and absence of `ROLE_admin` / `manage-users`
- [x] `LoginIT#adminLoginShowsAdminIdentityAndRoles` asserts name "Jane Doe", email, and presence of `ROLE_user`, `ROLE_admin`, `view-profile`, `manage-users`
- [ ] First CI run on this PR completes green