### PR TITLE
chore: update demo for Vaadin 25

### DIFF
--- a/sso-kit-demo/pom.xml
+++ b/sso-kit-demo/pom.xml
@@ -43,6 +43,7 @@
       <groupId>com.vaadin</groupId>
       <artifactId>vaadin-dev-server</artifactId>
       <version>${flow.version}</version>
+      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -125,38 +126,12 @@
         <executions>
           <execution>
             <goals>
-              <goal>prepare-frontend</goal>
+              <goal>build-frontend</goal>
             </goals>
           </execution>
         </executions>
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>production</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.vaadin</groupId>
-            <artifactId>flow-maven-plugin</artifactId>
-            <version>${flow.version}</version>
-            <configuration>
-              <productionMode>true</productionMode>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>build-frontend</goal>
-                </goals>
-                <phase>compile</phase>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 
 </project>


### PR DESCRIPTION
Replaces useless prepare-frontend goal with build-frontend, removes production profile and marks vaadin-dev-server as optional dependency so it does not end up in the final artifact
