### PR TITLE
Fix BackChannelLogoutFilter: accept typ=logout+jwt in decoder (Spring Security 7)

### DIFF
--- a/sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java
+++ b/sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java
@@ -98,6 +98,10 @@ public class BackChannelLogoutFilter extends GenericFilterBean {
                             .createDefaultWithValidators(typeValidator));
                     return decoder;
                 });
+        logger.warn("BackChannelLogoutFilter is deprecated and will be removed "
+                + "in the future. SpringSecurity provides equivalent function "
+                + "by default. Remove  `vaadin.sso.back-channel-logout=true` "
+                + "setting in your configuration.");
     }
 
     BackChannelLogoutFilter(SessionRegistry sessionRegistry,

--- a/sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java
+++ b/sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java
@@ -26,8 +26,10 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
-import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtTypeValidator;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.GenericFilterBean;
@@ -78,9 +80,23 @@ public class BackChannelLogoutFilter extends GenericFilterBean {
             ApplicationEventPublisher eventPublisher) {
         this(sessionRegistry, clientRegistrationRepository, eventPublisher,
                 clientRegistration -> {
-                    final var issuerUri = clientRegistration
-                            .getProviderDetails().getIssuerUri();
-                    return JwtDecoders.fromOidcIssuerLocation(issuerUri);
+                    final var jwkSetUri = clientRegistration
+                            .getProviderDetails().getJwkSetUri();
+                    // OpenID Connect Back-Channel Logout tokens use
+                    // typ=logout+jwt per the spec. Spring Security 7 enforces
+                    // typ=JWT by default, which breaks logout token decoding.
+                    // We disable that Nimbus-level check and replace it with a
+                    // JwtTypeValidator that explicitly accepts logout+jwt (and
+                    // tokens without a typ header for backward compatibility).
+                    final var typeValidator = new JwtTypeValidator(
+                            "logout+jwt");
+                    typeValidator.setAllowEmpty(true);
+                    final var decoder = NimbusJwtDecoder
+                            .withJwkSetUri(jwkSetUri).validateType(false)
+                            .build();
+                    decoder.setJwtValidator(JwtValidators
+                            .createDefaultWithValidators(typeValidator));
+                    return decoder;
                 });
     }
 

--- a/sso-kit-core/src/test/java/com/vaadin/sso/core/BackChannelLogoutDecoderTest.java
+++ b/sso-kit-core/src/test/java/com/vaadin/sso/core/BackChannelLogoutDecoderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2000-2025 Vaadin Ltd.
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full license.
+ */
+package com.vaadin.sso.core;
+
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Instant;
+import java.util.Date;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.JwtTypeValidator;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests that the decoder configuration used by
+ * {@link BackChannelLogoutFilter}'s public constructor correctly accepts
+ * OpenID Connect Back-Channel Logout tokens with {@code typ=logout+jwt} and
+ * rejects tokens carrying a different type.
+ */
+class BackChannelLogoutDecoderTest {
+
+    private static final String ISSUER_URI = "http://issuer.com";
+
+    private static final String CLIENT_ID = "test-client";
+
+    @Test
+    void decoderWithLogoutJwtType_acceptsLogoutToken() throws Exception {
+        final var keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        final var keyPair = keyPairGenerator.generateKeyPair();
+        final var publicKey = (RSAPublicKey) keyPair.getPublic();
+        final var privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        final var token = buildSignedJwt(privateKey, "logout+jwt");
+
+        final var typeValidator = new JwtTypeValidator("logout+jwt");
+        typeValidator.setAllowEmpty(true);
+        final var decoder = NimbusJwtDecoder.withPublicKey(publicKey)
+                .validateType(false).build();
+        decoder.setJwtValidator(
+                JwtValidators.createDefaultWithValidators(typeValidator));
+
+        final var jwt = decoder.decode(token);
+
+        assertThat(jwt.getSubject()).isEqualTo("john");
+    }
+
+    @Test
+    void decoderWithLogoutJwtType_rejectsJwtTypedToken() throws Exception {
+        final var keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        final var keyPair = keyPairGenerator.generateKeyPair();
+        final var publicKey = (RSAPublicKey) keyPair.getPublic();
+        final var privateKey = (RSAPrivateKey) keyPair.getPrivate();
+
+        // A regular JWT token (typ=JWT) must not be accepted as a logout token
+        final var token = buildSignedJwt(privateKey, "JWT");
+
+        final var typeValidator = new JwtTypeValidator("logout+jwt");
+        typeValidator.setAllowEmpty(true);
+        final var decoder = NimbusJwtDecoder.withPublicKey(publicKey)
+                .validateType(false).build();
+        decoder.setJwtValidator(
+                JwtValidators.createDefaultWithValidators(typeValidator));
+
+        assertThatThrownBy(() -> decoder.decode(token))
+                .isInstanceOf(JwtValidationException.class)
+                .hasMessageContaining("logout+jwt");
+    }
+
+    private static String buildSignedJwt(RSAPrivateKey privateKey, String typ)
+            throws Exception {
+        final var header = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                .type(new JOSEObjectType(typ)).build();
+        final var claimsSet = new JWTClaimsSet.Builder().issuer(ISSUER_URI)
+                .audience(CLIENT_ID)
+                .issueTime(Date.from(Instant.now())).subject("john").build();
+        final var signedJwt = new SignedJWT(header, claimsSet);
+        signedJwt.sign(new RSASSASigner(privateKey));
+        return signedJwt.serialize();
+    }
+}

--- a/sso-kit-core/src/test/java/com/vaadin/sso/core/BackChannelLogoutDecoderTest.java
+++ b/sso-kit-core/src/test/java/com/vaadin/sso/core/BackChannelLogoutDecoderTest.java
@@ -19,7 +19,6 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.jwt.JwtTypeValidator;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
@@ -31,9 +30,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests that the decoder configuration used by
- * {@link BackChannelLogoutFilter}'s public constructor correctly accepts
- * OpenID Connect Back-Channel Logout tokens with {@code typ=logout+jwt} and
- * rejects tokens carrying a different type.
+ * {@link BackChannelLogoutFilter}'s public constructor correctly accepts OpenID
+ * Connect Back-Channel Logout tokens with {@code typ=logout+jwt} and rejects
+ * tokens carrying a different type.
  */
 class BackChannelLogoutDecoderTest {
 
@@ -91,8 +90,8 @@ class BackChannelLogoutDecoderTest {
         final var header = new JWSHeader.Builder(JWSAlgorithm.RS256)
                 .type(new JOSEObjectType(typ)).build();
         final var claimsSet = new JWTClaimsSet.Builder().issuer(ISSUER_URI)
-                .audience(CLIENT_ID)
-                .issueTime(Date.from(Instant.now())).subject("john").build();
+                .audience(CLIENT_ID).issueTime(Date.from(Instant.now()))
+                .subject("john").build();
         final var signedJwt = new SignedJWT(header, claimsSet);
         signedJwt.sign(new RSASSASigner(privateKey));
         return signedJwt.serialize();


### PR DESCRIPTION
Spring Security 7's `NimbusJwtDecoder` enforces `typ=JWT` by default, breaking OIDC Back-Channel Logout which requires `typ=logout+jwt`. This causes a `JwtValidationException` at `BackChannelLogoutFilter.performLogout` on every logout attempt.

## Changes

**`BackChannelLogoutFilter` — public constructor decoder factory**

- Replaces `JwtDecoders.fromOidcIssuerLocation(issuerUri)` with `NimbusJwtDecoder.withJwkSetUri(...).validateType(false)`, disabling the Nimbus-level `typ=JWT` enforcement
- Adds an explicit `JwtTypeValidator("logout+jwt")` (with `allowEmpty=true` for providers that omit `typ`) via `JwtValidators.createDefaultWithValidators(...)`, which preserves the default timestamp and cert-thumbprint validators
- Uses `ClientRegistration.getProviderDetails().getJwkSetUri()` (already resolved at startup) instead of re-triggering OIDC discovery on each call

```java
// before
return JwtDecoders.fromOidcIssuerLocation(issuerUri);

// after
final var typeValidator = new JwtTypeValidator("logout+jwt");
typeValidator.setAllowEmpty(true);
final var decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
        .validateType(false)
        .build();
decoder.setJwtValidator(JwtValidators.createDefaultWithValidators(typeValidator));
return decoder;
```

Existing `OidcLogoutTokenValidator` claim validation (ISS, AUD, events, sub/sid, nonce) is unchanged and still runs after decoding.

**`BackChannelLogoutDecoderTest` — new test class**

- `decoderWithLogoutJwtType_acceptsLogoutToken` — real RSA-signed JWT with `typ=logout+jwt` decodes successfully
- `decoderWithLogoutJwtType_rejectsJwtTypedToken` — `typ=JWT` token is rejected, preventing access tokens from being misused as logout tokens

> [!WARNING]
>
> <details>
> <summary>Firewall rules blocked me from connecting to one or more addresses (expand for details)</summary>
>
> #### I tried to connect to the following addresses, but was blocked by firewall rules:
>
> - `maven.vaadin.com`
>   - Triggering command: `/usr/lib/jvm/temurin-17-jdk-amd64/bin/java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java --enable-native-access=ALL-UNNAMED -classpath /usr/share/apache-maven-3.9.14/boot/plexus-classworlds-2.9.0.jar -Dclassworlds.conf=/usr/share/apache-maven-3.9.14/bin/m2.conf -Dmaven.home=/usr/share/apache-maven-3.9.14 -Dlibrary.jansi.path=/usr/share/apache-maven-3.9.14/lib/jansi-native -Dmaven.multiModuleProjectDirectory=/home/REDACTED/work/sso-kit/sso-kit org.codehaus.plexus.classworlds.launcher.Launcher dependency:tree -pl sso-kit-core -Dincludes=org.springframework.security:spring-security-oauth2-jose,com.nimbusds:nimbus-jose-jwt` (dns block)
>   - Triggering command: `/usr/lib/jvm/temurin-17-jdk-amd64/bin/java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java --enable-native-access=ALL-UNNAMED -classpath /usr/share/apache-maven-3.9.14/boot/plexus-classworlds-2.9.0.jar -Dclassworlds.conf=/usr/share/apache-maven-3.9.14/bin/m2.conf -Dmaven.home=/usr/share/apache-maven-3.9.14 -Dlibrary.jansi.path=/usr/share/apache-maven-3.9.14/lib/jansi-native -Dmaven.multiModuleProjectDirectory=/home/REDACTED/work/sso-kit/sso-kit org.codehaus.plexus.classworlds.launcher.Launcher dependency:tree -pl sso-kit-core` (dns block)
>   - Triggering command: `/usr/lib/jvm/temurin-17-jdk-amd64/bin/java /usr/lib/jvm/temurin-17-jdk-amd64/bin/java --enable-native-access=ALL-UNNAMED -classpath /usr/share/apache-maven-3.9.14/boot/plexus-classworlds-2.9.0.jar -Dclassworlds.conf=/usr/share/apache-maven-3.9.14/bin/m2.conf -Dmaven.home=/usr/share/apache-maven-3.9.14 -Dlibrary.jansi.path=/usr/share/apache-maven-3.9.14/lib/jansi-native -Dmaven.multiModuleProjectDirectory=/home/REDACTED/work/sso-kit/sso-kit org.codehaus.plexus.classworlds.launcher.Launcher dependency:list -pl sso-kit-core -q` (dns block)
>
> If you need me to access, download, or install something from one of these locations, you can either:
>
> - Configure [Actions setup steps](https://gh.io/copilot/actions-setup-steps) to set up my environment, which run before the firewall is enabled
> - Add the appropriate URLs or hosts to the custom allowlist in this repository's [Copilot coding agent settings](https://github.com/TatuLund/sso-kit/settings/copilot/coding_agent) (admins only)
>
> </details>

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> Create a pull request in repository `TatuLund/sso-kit` to fix OpenID Connect back-channel logout token decoding in `sso-kit-core/src/main/java/com/vaadin/sso/core/BackChannelLogoutFilter.java`.
> 
> Context:
> - The current implementation decodes the logout token at approximately line 147 with:
>   `final var jwt = decoder.decode(token);`
> - Runtime failure observed:
>   `org.springframework.security.oauth2.jwt.JwtValidationException: An error occurred while attempting to decode the Jwt: the given typ value needs to be one of [JWT]`
> - Stack trace points to `BackChannelLogoutFilter.performLogout`.
> - The user wants the implementation changed so that it uses a custom decoder that accepts `typ = "logout+jwt"` and disables the default type validation for the decoder created around line 146.
> 
> Requested change:
> 1. Modify the implementation so back-channel logout token decoding supports OpenID Connect Back-Channel Logout tokens with header `typ=logout+jwt`.
> 2. Ensure the decoder used in `BackChannelLogoutFilter` does not reject the token because of Spring Security's default `typ` validation expecting `JWT`.
> 3. Use a custom decoder or decoder factory approach appropriate for Spring Security 7.0.x / NimbusJwtDecoder so that default type validation is disabled and the implementation explicitly validates the correct logout token type.
> 4. Preserve or improve existing validation behavior by keeping logout-token-specific validation in place, ideally integrating or complementing `OidcLogoutTokenValidator`.
> 5. Add or update tests to cover successful decoding/validation of a logout token with `typ=logout+jwt` and to ensure invalid tokens are still rejected.
> 
> Implementation notes:
> - Investigate how the decoder is currently created via the `JwtDecoderFactory<ClientRegistration>` in `BackChannelLogoutFilter`.
> - Prefer a targeted change that affects back-channel logout decoding only, not global JWT decoding.
> - If needed, add a dedicated decoder factory/helper class in `sso-kit-core` for logout tokens.
> - Keep the API surface minimal unless refactoring is clearly beneficial.
> 
> Acceptance criteria:
> - A back-channel logout token with `typ=logout+jwt` no longer throws the shown `JwtValidationException` during decoding.
> - Back-channel logout flow still returns bad request for invalid/malformed/incorrect logout tokens.
> - Tests demonstrate the new behavior.
> - PR should include a concise explanation of why default `typ` validation had to be disabled and how logout-token validation is now enforced.
> 
> The following is the prior conversation context from the user's chat exploration (may be truncated):
> 
> User: ```
> org.springframework.security.oauth2.jwt.JwtValidationException: An error occurred while attempting to decode the Jwt: the given typ value needs to be one of [JWT]
> 
>       at org.springframework.security.oauth2.jwt.NimbusJwtDecoder.validateJwt(NimbusJwtDecoder.java:199) ~[spring-security-oauth2-jose-7.0.4.jar:7.0.4]
> 
>       at org.springframework.security.oauth2.jwt.NimbusJwtDecoder.decode(NimbusJwtDecoder.java:145) ~[spring-security-oauth2-jose-7.0.4.jar:7.0.4]
> 
>       at com.vaadin.sso.core.BackChannelLogoutFilter.performLogout(BackChannelLogoutFilter.java:147) ~[sso-kit-core-4.1.0.jar:?]
> 
>       at com.vaadin.sso.core.BackChannelLogoutFilter.doFilter(BackChannelLogoutFilter.java:106) ~[sso-kit-core-4.1.0.jar:?]
> ```
> I get this exception
> 
> Propose me PR that changes the implementation use custom decoder that accepts typ = "logout+jwt". And disables type validation for decoder created line 146.
> 
> Assistant: I’m waiting for your response to the pull request proposal dialog so I can continue.
> 
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created from Copilot chat.*
>