### PR TITLE
Replace pull_request_target with pull_request in CI workflow

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,7 +2,7 @@ name: Integration Test
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
   workflow_dispatch:
@@ -13,12 +13,13 @@ concurrency:
   group: it-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   JAVA_VERSION: '21'
   APP_URL: http://localhost:8080
   KEYCLOAK_URL: http://localhost:8180
 jobs:
   integration-test:
-    environment: ${{ github.event.pull_request.head.repo.fork && 'pr-tests' || '' }}
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     timeout-minutes: 45
     runs-on: ubuntu-24.04
     steps:
@@ -88,7 +89,7 @@ jobs:
         run: docker compose -f sso-kit-demo/docker-compose.yml logs keycloak > keycloak.log 2>&1 || true
       - name: Upload diagnostics on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: integration-test-diagnostics
           path: |

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,8 +52,10 @@ jobs:
       uses: actions/cache@v4
       id: cache-node_modules
       with:
-        path: sso-kit-client/node_modules
-        key: ${{ runner.os }}-node_modules-${{ hashFiles('sso-kit-client/package-lock.json') }}
+        path: |
+          sso-kit-client/node_modules
+          sso-kit-client/*/node_modules
+        key: ${{ runner.os }}-node_modules-v2-${{ hashFiles('sso-kit-client/package-lock.json') }}
     - name: Install npm dependencies
       if: ${{ steps.cache-node_modules.outputs.cache-hit != 'true' }}
       shell: bash


### PR DESCRIPTION
## Summary

Replaces `pull_request_target` with `pull_request` in `integration-test.yml`.

Removes the `environment: pr-tests` gate. Integration test job skips entirely for fork PRs since `TB_LICENSE` is not available. Bumps `actions/upload-artifact` to v5 and adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.